### PR TITLE
Change issue trigger from created to opened

### DIFF
--- a/.github/workflows/issue-workflow.yml
+++ b/.github/workflows/issue-workflow.yml
@@ -2,7 +2,7 @@ name: Issue Workflow
 
 on:
   issues:
-    types: [created]
+    types: [opened]
 
 jobs:
   run-workspace:


### PR DESCRIPTION
Updates the GitHub Actions workflow to trigger on issue events of type `opened` instead of `created`.
- Changes the event type from `created` to `opened` in the `.github/workflows/issue-workflow.yml` file to ensure the workflow is triggered correctly when an issue is opened.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AnandChowdhary/smol-github-workspace?shareId=2df0d028-6c59-4c90-bc64-7c17d82ae0af).