### PR TITLE
Replace import statement with require in workspace.js

### DIFF
--- a/workspace.js
+++ b/workspace.js
@@ -1,4 +1,4 @@
-import fs from "fs";
+const fs = require("fs");
 const { Octokit } = require("@octokit/action");
 const OpenAI = require("openai");
 


### PR DESCRIPTION
Updates the module import syntax in `workspace.js` to use `require` instead of `import` for consistency and compatibility.

- Replaces the `import fs from "fs";` statement with `const fs = require('fs');` to address the SyntaxError issue when using import statements outside a module.
- Ensures all other module imports in `workspace.js` consistently use the `require` syntax, aligning with the task's objective to use `require` throughout the file.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AnandChowdhary/smol-github-workspace?shareId=1c2c8f5f-f6a4-4ad6-a7da-ce68cd81cdd7).